### PR TITLE
Bug fix in saving PCI bridge device info

### DIFF
--- a/opencis/drivers/pci_bus_driver.py
+++ b/opencis/drivers/pci_bus_driver.py
@@ -557,11 +557,11 @@ class PciBusDriver(LabeledComponent):
             is_bridge = (class_code >> 8) == BRIDGE_CLASS
             if bdf not in existing_bdfs:
                 pci_device_info = PciDeviceInfo(
-                    bdf,
-                    vendor_id,
-                    device_id,
-                    class_code,
-                    is_bridge,
+                    bdf=bdf,
+                    vendor_id=vendor_id,
+                    device_id=device_id,
+                    class_code=class_code,
+                    is_bridge=is_bridge,
                 )
                 if parent_device_info:
                     parent_device_info.children.append(pci_device_info)


### PR DESCRIPTION
There is `serial_number` between `class_code` and `is_bridge`. Set it directly to avoid param order issue.