### PR TITLE
Add support for interleaving by CxlHost

### DIFF
--- a/demos/image-classification/host-t1.py
+++ b/demos/image-classification/host-t1.py
@@ -59,7 +59,7 @@ config = None
 start_signal = None
 stop_signal = None
 host = None
-start_tasks = None
+host_task = None
 
 
 async def my_sys_sw_app(**kwargs):
@@ -343,12 +343,10 @@ async def main():
     global host
     global host_task
 
-    global host_task
-
     cxl_host_config = CxlHostConfig(
         port_index=0,
         sys_mem_size=(2 * MB),
-        sys_sw_app=lambda **kwargs: my_sys_sw_app(**kwargs),
+        sys_sw_app=my_sys_sw_app,
         user_app=my_img_classification_app,
         host_name="ImageHostType1",
         switch_port=sw_portno,

--- a/demos/image-classification/host-t1.py
+++ b/demos/image-classification/host-t1.py
@@ -18,7 +18,7 @@ from typing import Dict
 from tqdm.auto import tqdm
 
 from opencis.util.logger import logger
-from opencis.cxl.component.cxl_host import CxlHost
+from opencis.cxl.component.cxl_host import CxlHost, CxlHostConfig
 from opencis.cpu import CPU
 from opencis.util.number_const import MB
 from opencis.cxl.component.cxl_memory_hub import CxlMemoryHub, MEM_ADDR_TYPE
@@ -62,7 +62,8 @@ host = None
 start_tasks = None
 
 
-async def my_sys_sw_app(cxl_memory_hub: CxlMemoryHub):
+async def my_sys_sw_app(**kwargs):
+    cxl_memory_hub = kwargs["cxl_memory_hub"]
     pci_cfg_base_addr = config.pci_cfg_base_addr
     pci_mmio_base_addr = config.pci_mmio_base_addr
     cxl_hpa_base_addr = config.cxl_hpa_base_addr
@@ -302,7 +303,7 @@ async def shutdown(signame=None):
             asyncio.create_task(host.stop()),
         ]
         await asyncio.gather(*stop_tasks, return_exceptions=True)
-        await asyncio.gather(*start_tasks)
+        host_task.cancel()
     except Exception as exc:
         print("[HOST]", exc.__traceback__)
     finally:
@@ -340,21 +341,21 @@ async def main():
     stop_signal = asyncio.Event()
 
     global host
-    global start_tasks
+    global host_task
 
-    host = CxlHost(
+    global host_task
+
+    cxl_host_config = CxlHostConfig(
         port_index=0,
         sys_mem_size=(2 * MB),
-        sys_sw_app=my_sys_sw_app,
+        sys_sw_app=lambda **kwargs: my_sys_sw_app(**kwargs),
         user_app=my_img_classification_app,
         host_name="ImageHostType1",
         switch_port=sw_portno,
         enable_hm=False,
     )
-    start_tasks = [
-        asyncio.create_task(host.run()),
-    ]
-    await host.wait_for_ready()
+    host = CxlHost(cxl_host_config)
+    host_task = asyncio.create_task(host.run())
 
     # install signal handlers
     lp = asyncio.get_event_loop()

--- a/demos/image-classification/host-t1.py
+++ b/demos/image-classification/host-t1.py
@@ -53,8 +53,8 @@ host_irq_handler = None
 total_samples = 0
 validation_results = []
 sampled_file_categories = []
-cpu = None
-mem_hub = None
+cpu: CPU = None
+mem_hub: CxlMemoryHub = None
 config = None
 start_signal = None
 stop_signal = None
@@ -248,12 +248,12 @@ def merge_validation_results():
     )
 
 
-async def my_img_classification_app(_cpu: CPU, _mem_hub: CxlMemoryHub):
+async def my_img_classification_app(**kwargs):
     global cpu
-    cpu = _cpu
+    cpu = kwargs["cpu"]
 
     global mem_hub
-    mem_hub = _mem_hub
+    mem_hub = kwargs["cxl_memory_hub"]
 
     # Pass init-info mem location to the remote using MMIO
     logger.info("Host main process waiting...")

--- a/demos/image-classification/host-t2.py
+++ b/demos/image-classification/host-t2.py
@@ -54,8 +54,8 @@ host_irq_handler = None
 total_samples = 0
 validation_results = []
 sampled_file_categories = []
-cpu = None
-mem_hub = None
+cpu: CPU = None
+mem_hub: CxlMemoryHub = None
 config = None
 start_signal = None
 stop_signal = None
@@ -237,12 +237,12 @@ def merge_validation_results():
     )
 
 
-async def my_img_classification_app(_cpu: CPU, _mem_hub: CxlMemoryHub):
+async def my_img_classification_app(**kwargs):
     global cpu
-    cpu = _cpu
+    cpu = kwargs["cpu"]
 
     global mem_hub
-    mem_hub = _mem_hub
+    mem_hub = kwargs["cxl_memory_hub"]
 
     # Pass init-info mem location to the remote using MMIO
     CSV_DATA_MEM_OFFSET = 0x4000

--- a/demos/image-classification/host-t2.py
+++ b/demos/image-classification/host-t2.py
@@ -17,7 +17,7 @@ from signal import SIGCONT, SIGINT, SIGIO
 from typing import Dict
 
 from opencis.util.logger import logger
-from opencis.cxl.component.cxl_host import CxlHost
+from opencis.cxl.component.cxl_host import CxlHost, CxlHostConfig
 from opencis.cpu import CPU
 from opencis.util.number_const import MB
 from opencis.cxl.component.cxl_memory_hub import CxlMemoryHub, MEM_ADDR_TYPE
@@ -63,7 +63,8 @@ host = None
 start_tasks = None
 
 
-async def my_sys_sw_app(cxl_memory_hub: CxlMemoryHub):
+async def my_sys_sw_app(**kwargs):
+    cxl_memory_hub = kwargs["cxl_memory_hub"]
     pci_cfg_base_addr = config.pci_cfg_base_addr
     pci_mmio_base_addr = config.pci_mmio_base_addr
     cxl_hpa_base_addr = config.cxl_hpa_base_addr
@@ -329,15 +330,15 @@ async def main():
     global host
     global start_tasks
 
-    host = CxlHost(
+    cxl_host_config = CxlHostConfig(
         port_index=0,
         sys_mem_size=(2 * MB),
-        sys_sw_app=my_sys_sw_app,
+        sys_sw_app=lambda **kwargs: my_sys_sw_app(**kwargs),
         user_app=my_img_classification_app,
-        host_name="ImageHostType2",
         switch_port=sw_portno,
         enable_hm=False,
     )
+    host = CxlHost(cxl_host_config)
     start_tasks = [
         asyncio.create_task(host.run()),
     ]

--- a/demos/image-classification/host-t2.py
+++ b/demos/image-classification/host-t2.py
@@ -342,7 +342,6 @@ async def main():
     start_tasks = [
         asyncio.create_task(host.run()),
     ]
-    await host.wait_for_ready()
 
     # install signal handlers
     lp = asyncio.get_event_loop()

--- a/demos/image-classification/run-demo.py
+++ b/demos/image-classification/run-demo.py
@@ -9,7 +9,6 @@ import argparse
 from signal import SIGCONT, SIGINT, SIGIO, SIG_BLOCK, SIG_UNBLOCK, pthread_sigmask, signal, pause
 
 import os
-import inspect
 
 from opencis.util.logger import logger
 
@@ -23,10 +22,8 @@ def clean_shutdown(signum=None, frame=None):
     pthread_sigmask(SIG_BLOCK, [SIGINT])
 
     global pids
-    print(f"{__file__}, Line: {inspect.currentframe().f_lineno}")
     pids = dict(reversed(pids.items()))
     for _, pid in pids.items():
-        print(f"{__file__}, {pid}, l:{inspect.currentframe().f_lineno}")
         os.kill(pid, SIGINT)
         os.waitpid(pid, 0)
     os._exit(0)
@@ -42,7 +39,7 @@ def run_next_app(signum=None, frame=None):
         host_pid = pids["host"]
         os.kill(host_pid, SIGIO)
         return
-    logger.info(f"{RUN_LIST}: {run_progress} ")
+
     component_name, program, args = RUN_LIST[run_progress]
 
     if not (chld := os.fork()):

--- a/demos/image-classification/run-demo.py
+++ b/demos/image-classification/run-demo.py
@@ -9,6 +9,7 @@ import argparse
 from signal import SIGCONT, SIGINT, SIGIO, SIG_BLOCK, SIG_UNBLOCK, pthread_sigmask, signal, pause
 
 import os
+import inspect
 
 from opencis.util.logger import logger
 
@@ -22,8 +23,10 @@ def clean_shutdown(signum=None, frame=None):
     pthread_sigmask(SIG_BLOCK, [SIGINT])
 
     global pids
+    print(f"{__file__}, Line: {inspect.currentframe().f_lineno}")
     pids = dict(reversed(pids.items()))
     for _, pid in pids.items():
+        print(f"{__file__}, {pid}, l:{inspect.currentframe().f_lineno}")
         os.kill(pid, SIGINT)
         os.waitpid(pid, 0)
     os._exit(0)
@@ -39,7 +42,7 @@ def run_next_app(signum=None, frame=None):
         host_pid = pids["host"]
         os.kill(host_pid, SIGIO)
         return
-
+    logger.info(f"{RUN_LIST}: {run_progress} ")
     component_name, program, args = RUN_LIST[run_progress]
 
     if not (chld := os.fork()):

--- a/opencis/apps/memory_pooling.py
+++ b/opencis/apps/memory_pooling.py
@@ -74,15 +74,6 @@ class MemoryBaseTracker:
 host_fm_conn = None
 
 
-async def init_cxl_devices_interleave(
-    cxl_mem_driver: CxlMemDriver,
-    hpa_base: int,
-    ig: INTERLEAVE_GRANULARITY = INTERLEAVE_GRANULARITY.SIZE_256B,
-    iw: INTERLEAVE_WAYS = INTERLEAVE_WAYS.WAY_1,
-):
-    pass
-
-
 async def my_sys_sw_app(ig: int = None, iw: int = None, **kwargs):
     cxl_memory_hub: CxlMemoryHub
 
@@ -349,4 +340,4 @@ async def run_host(port_index: int, irq_port: int, ig: int, iw: int):
 
 
 if __name__ == "__main__":
-    asyncio.run(run_host(port_index=0, irq_port=8500))
+    asyncio.run(run_host(port_index=0, irq_port=8500, ig=0, iw=2))

--- a/opencis/apps/memory_pooling.py
+++ b/opencis/apps/memory_pooling.py
@@ -197,6 +197,7 @@ async def my_sys_sw_app(ig: int = None, iw: int = None, **kwargs):
                 mem_tracker.add_mem_range(
                     vppb, memory_base_tracker.hpa_base, size, MEM_ADDR_TYPE.CXL_UNCACHED
                 )
+            memory_base_tracker.hpa_base += size
 
     # System Memory
     sys_mem_size = root_complex.get_sys_mem_size()

--- a/opencis/apps/memory_pooling.py
+++ b/opencis/apps/memory_pooling.py
@@ -144,7 +144,7 @@ async def my_sys_sw_app(ig: int = None, iw: int = None, **kwargs):
 
         # setup HDM decoder for devices
         for device in cxl_mem_driver.get_devices():
-            successful = await cxl_mem_driver.config_single_mem_device(
+            successful = await cxl_mem_driver.config_cxl_mem_device(
                 device, hpa_base, interleaved_mem_size, ig=ig, iw=iw
             )
             if not successful:

--- a/opencis/apps/memory_pooling.py
+++ b/opencis/apps/memory_pooling.py
@@ -179,7 +179,7 @@ async def my_sys_sw_app(ig: int = None, iw: int = None, **kwargs):
         for device in cxl_mem_driver.get_devices():
             size = device.get_memory_size()
             successful = await cxl_mem_driver.attach_single_mem_device(
-                device, hpa_base, device.get_memory_size(), ig=ig, iw=iw
+                device, memory_base_tracker.hpa_base, size
             )
             sn = device.pci_device_info.serial_number
             vppb = cxl_mem_driver.get_port_number(device)

--- a/opencis/apps/memory_pooling.py
+++ b/opencis/apps/memory_pooling.py
@@ -333,7 +333,7 @@ async def sample_app(_cpu: CPU, _mem_hub: CxlMemoryHub):
     val = await _cpu.load(0x100000000040, 0x40)
     logger.info(f"0x{val:X}")
 
-    await asyncio.Event().wait()  # keep the host app alive
+    # await asyncio.Event().wait()  # keep the host app alive
 
 
 async def run_host(port_index: int, irq_port: int, ig: int, iw: int):

--- a/opencis/bin/cli.py
+++ b/opencis/bin/cli.py
@@ -78,6 +78,8 @@ def validate_log_level(ctx, param, level):
 @click.option("--show-timestamp", is_flag=True, default=False, help="Show timestamp.")
 @click.option("--show-loglevel", is_flag=True, default=False, help="Show log level.")
 @click.option("--show-linenumber", is_flag=True, default=False, help="Show line number.")
+@click.option("--ig", help="Interleave granularity")
+@click.option("--iw", help="Interleave ways")
 def start(
     ctx,
     comp,
@@ -88,6 +90,8 @@ def start(
     show_timestamp,
     show_loglevel,
     show_linenumber,
+    ig,
+    iw,
 ):
     """Start components"""
 
@@ -172,11 +176,13 @@ def start(
             processes.append(p_hm)
             p_hm.start()
         if "host" in comp:
-            p_host = multiprocessing.Process(target=start_host, args=(ctx,))
+            p_host = multiprocessing.Process(target=start_host, args=(ctx, ig, iw))
             processes.append(p_host)
             p_host.start()
         elif "host-group" in comp:
-            p_hgroup = multiprocessing.Process(target=start_host_group, args=(ctx, config_file))
+            p_hgroup = multiprocessing.Process(
+                target=start_host_group, args=(ctx, config_file, ig, iw)
+            )
             processes.append(p_hgroup)
             p_hgroup.start()
 
@@ -210,8 +216,8 @@ def start_host(ctx):
     ctx.invoke(cxl_host.start)
 
 
-def start_host_group(ctx, config_file):
-    ctx.invoke(cxl_host.start_group, config_file=config_file)
+def start_host_group(ctx, config_file, ig, iw):
+    ctx.invoke(cxl_host.start_group, config_file=config_file, ig=ig, iw=iw)
 
 
 def start_sld(ctx, config_file):

--- a/opencis/bin/cxl_host.py
+++ b/opencis/bin/cxl_host.py
@@ -32,7 +32,7 @@ def start_host_manager():
     asyncio.run(host_manager.wait_for_ready())
 
 
-async def run_host_group(ports):
+async def run_host_group(ports, ig, iw):
     irq_port = 8500
     tasks = []
     for idx in ports:
@@ -41,6 +41,8 @@ async def run_host_group(ports):
                 run_host(
                     port_index=idx,
                     irq_port=irq_port,
+                    ig=ig,
+                    iw=iw,
                 )
             )
         )
@@ -48,7 +50,7 @@ async def run_host_group(ports):
     await asyncio.gather(*tasks)
 
 
-def start_group(config_file: str):
+def start_group(config_file: str, ig: int = 0, iw: int = 0):
     logger.info(f"Starting CXL Host Group - Config: {config_file}")
     try:
         environment = parse_cxl_environment(config_file)
@@ -60,4 +62,4 @@ def start_group(config_file: str):
     for idx, port_config in enumerate(environment.switch_config.port_configs):
         if port_config.type == PORT_TYPE.USP:
             ports.append(idx)
-    asyncio.run(run_host_group(ports))
+    asyncio.run(run_host_group(ports, ig, iw))

--- a/opencis/bin/cxl_host.py
+++ b/opencis/bin/cxl_host.py
@@ -20,9 +20,9 @@ def host_group():
     """Command group for managing CXL Host"""
 
 
-def start(port: int = 0):
+def start(port, ig, iw):
     logger.info(f"Starting CXL Host on Port{port}")
-    asyncio.run(run_host(port_index=port, irq_port=8500))
+    asyncio.run(run_host(port_index=port, irq_port=8500, ig=ig, iw=iw))
 
 
 def start_host_manager():

--- a/opencis/cpu.py
+++ b/opencis/cpu.py
@@ -100,15 +100,9 @@ class CPU(RunnableComponent):
         await self._run_sys_sw_app()
         self._app_task = asyncio.create_task(self._app_run_task())
         await self._change_status_to_running()
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
         await self._app_task
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
-        res = await self._fut
-        logger.info(f"{res} File: {__file__}, Line: {inspect.currentframe().f_lineno}")
+        await self._fut
 
     async def _stop(self):
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
         self._app_task.cancel()
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
         self._fut.set_result("CPU Done")
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")

--- a/opencis/cpu.py
+++ b/opencis/cpu.py
@@ -31,6 +31,11 @@ class CPU(RunnableComponent):
         kwargs["cxl_memory_hub"] = self._cxl_memory_hub
         await self._sys_sw_app(*args, **kwargs)
 
+    async def _run_user_app(self, *args, **kwargs):
+        kwargs["cpu"] = self
+        kwargs["cxl_memory_hub"] = self._cxl_memory_hub
+        await self._user_app(*args, **kwargs)
+
     def create_message(self, message):
         return self._create_message(message)
 
@@ -94,10 +99,10 @@ class CPU(RunnableComponent):
         return await self._user_app(_cpu=self, _mem_hub=self._cxl_memory_hub)
 
     async def _run(self):
-        self._fut = asyncio.Future()
         await self._run_sys_sw_app()
-        self._app_task = asyncio.create_task(self._app_run_task())
+        self._app_task = asyncio.create_task(self._run_user_app())
         await self._change_status_to_running()
+        self._fut = asyncio.Future()
         await self._app_task
         await self._fut
 

--- a/opencis/cpu.py
+++ b/opencis/cpu.py
@@ -8,9 +8,7 @@
 import asyncio
 from typing import Callable, Awaitable
 from tqdm.auto import tqdm
-import inspect
 
-from opencis.util.logger import logger
 from opencis.util.component import RunnableComponent
 from opencis.cxl.component.cxl_memory_hub import CxlMemoryHub
 

--- a/opencis/cxl/component/cache_controller.py
+++ b/opencis/cxl/component/cache_controller.py
@@ -44,6 +44,9 @@ class MemoryRange:
     size: int
     addr_type: MEM_ADDR_TYPE
 
+    def __hash__(self):
+        return hash((self.base_addr, self.size, self.addr_type))
+
 
 class COH_STATE_MACHINE(Enum):
     COH_STATE_INIT = auto()
@@ -121,7 +124,7 @@ class CacheController(RunnableComponent):
         self._cache_to_coh_bridge_fifo = config.cache_to_coh_bridge_fifo
         self._coh_bridge_to_cache_fifo = config.coh_bridge_to_cache_fifo
 
-        self._memory_ranges: List[MemoryRange] = []
+        self._memory_ranges: set[MemoryRange] = set()
 
         self.init_cache()
         logger.debug(self._create_message(f"{config.component_name} LLC Generated"))
@@ -146,7 +149,7 @@ class CacheController(RunnableComponent):
         logger.info(
             self._create_message(f"Adding MemoryRange addr: 0x{addr:x} addr_type: {addr_type.name}")
         )
-        self._memory_ranges.append(MemoryRange(base_addr=addr, size=size, addr_type=addr_type))
+        self._memory_ranges.add(MemoryRange(base_addr=addr, size=size, addr_type=addr_type))
 
     def remove_mem_range(self, base_addr: int, size: int, addr_type: MEM_ADDR_TYPE):
         r = MemoryRange(base_addr, size, addr_type)

--- a/opencis/cxl/component/cache_controller.py
+++ b/opencis/cxl/component/cache_controller.py
@@ -124,7 +124,7 @@ class CacheController(RunnableComponent):
         self._cache_to_coh_bridge_fifo = config.cache_to_coh_bridge_fifo
         self._coh_bridge_to_cache_fifo = config.coh_bridge_to_cache_fifo
 
-        self._memory_ranges: set[MemoryRange] = set()
+        self._memory_ranges: List[MemoryRange] = []
 
         self.init_cache()
         logger.debug(self._create_message(f"{config.component_name} LLC Generated"))
@@ -149,7 +149,7 @@ class CacheController(RunnableComponent):
         logger.info(
             self._create_message(f"Adding MemoryRange addr: 0x{addr:x} addr_type: {addr_type.name}")
         )
-        self._memory_ranges.add(MemoryRange(base_addr=addr, size=size, addr_type=addr_type))
+        self._memory_ranges.append(MemoryRange(base_addr=addr, size=size, addr_type=addr_type))
 
     def remove_mem_range(self, base_addr: int, size: int, addr_type: MEM_ADDR_TYPE):
         r = MemoryRange(base_addr, size, addr_type)

--- a/opencis/cxl/component/cxl_host.py
+++ b/opencis/cxl/component/cxl_host.py
@@ -102,8 +102,8 @@ class CxlHost(RunnableComponent):
         tasks = [
             await self._irq_manager.run_wait_ready(),
             await self._cxl_memory_hub.run_wait_ready(),
-            await self._cpu.run_wait_ready(),
         ]
+        tasks.append(asyncio.create_task(self._cpu.run()))
         if self._enable_hm:
             tasks.append(asyncio.create_task(self._host_mgr_conn_client.run()))
             await self._host_mgr_conn_client.wait_for_ready()

--- a/opencis/cxl/component/cxl_host.py
+++ b/opencis/cxl/component/cxl_host.py
@@ -7,8 +7,7 @@
 
 import asyncio
 from typing import Callable, Awaitable
-from dataclasses import dataclass, field
-import inspect
+from dataclasses import dataclass
 
 from opencis.util.logger import logger
 from opencis.util.component import RunnableComponent

--- a/opencis/cxl/component/cxl_host.py
+++ b/opencis/cxl/component/cxl_host.py
@@ -104,6 +104,7 @@ class CxlHost(RunnableComponent):
             await self._cxl_memory_hub.run_wait_ready(),
         ]
         tasks.append(asyncio.create_task(self._cpu.run()))
+        await self._cpu.wait_for_ready()
         if self._enable_hm:
             tasks.append(asyncio.create_task(self._host_mgr_conn_client.run()))
             await self._host_mgr_conn_client.wait_for_ready()

--- a/opencis/cxl/component/cxl_host.py
+++ b/opencis/cxl/component/cxl_host.py
@@ -8,6 +8,7 @@
 import asyncio
 from typing import Callable, Awaitable
 from dataclasses import dataclass, field
+import inspect
 
 from opencis.util.logger import logger
 from opencis.util.component import RunnableComponent
@@ -103,19 +104,30 @@ class CxlHost(RunnableComponent):
             await self._irq_manager.run_wait_ready(),
             await self._cxl_memory_hub.run_wait_ready(),
         ]
-        tasks.append(asyncio.create_task(self._cpu.run()))
+        t = asyncio.create_task(self._cpu.run())
         await self._cpu.wait_for_ready()
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
         if self._enable_hm:
             tasks.append(asyncio.create_task(self._host_mgr_conn_client.run()))
             await self._host_mgr_conn_client.wait_for_ready()
 
         await self._change_status_to_running()
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
+        logger.info(f"{tasks}")
         await asyncio.gather(*tasks)
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
+        await t
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
 
     async def _stop(self):
-        tasks = [
-            asyncio.create_task(self._cxl_memory_hub.stop()),
-            asyncio.create_task(self._cpu.stop()),
-            asyncio.create_task(self._irq_manager.stop()),
-        ]
-        await asyncio.gather(*tasks)
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
+        t1 = asyncio.create_task(self._cxl_memory_hub.stop())
+        t2 = asyncio.create_task(self._cpu.stop())
+        t3 = asyncio.create_task(self._irq_manager.stop())
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
+        await t1
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
+        await t3
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
+        await t2
+        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")

--- a/opencis/cxl/component/cxl_host.py
+++ b/opencis/cxl/component/cxl_host.py
@@ -7,6 +7,7 @@
 
 import asyncio
 from typing import Callable, Awaitable
+from dataclasses import dataclass, field
 
 from opencis.util.logger import logger
 from opencis.util.component import RunnableComponent
@@ -19,60 +20,64 @@ from opencis.cxl.component.irq_manager import IrqManager
 from opencis.cxl.component.host_manager import HostMgrConnClient, Result
 
 
+@dataclass
+class CxlHostConfig:
+    port_index: int
+    sys_mem_size: int
+    sys_sw_app: Callable[[], Awaitable[None]]
+    user_app: Callable[[], Awaitable[None]]
+    host_name: str = None
+    switch_host: str = "0.0.0.0"
+    switch_port: int = 8000
+    irq_host: str = "0.0.0.0"
+    irq_port: int = 8500
+    host_conn_host: str = "0.0.0.0"
+    host_conn_port: int = 8300
+    enable_hm: bool = True
+
+
 class CxlHost(RunnableComponent):
-    def __init__(
-        self,
-        port_index: int,
-        sys_mem_size: int,
-        sys_sw_app: Callable[[], Awaitable[None]],
-        user_app: Callable[[], Awaitable[None]],
-        host_name: str = None,
-        switch_host: str = "0.0.0.0",
-        switch_port: int = 8000,
-        irq_host: str = "0.0.0.0",
-        irq_port: int = 8500,
-        host_conn_host: str = "0.0.0.0",
-        host_conn_port: int = 8300,
-        enable_hm: int = True,
-    ):
-        label = f"Port{port_index}"
+    def __init__(self, config: CxlHostConfig):
+        label = f"Port{config.port_index}"
         super().__init__(label)
-        self._port_index = port_index
-        root_ports = [RootPortClientConfig(port_index, switch_host, switch_port)]
-        host_name = host_name if host_name else f"CxlHostPort{port_index}"
+        self._port_index = config.port_index
+        root_ports = [
+            RootPortClientConfig(config.port_index, config.switch_host, config.switch_port)
+        ]
+        host_name = config.host_name if config.host_name else f"CxlHostPort{config.port_index}"
 
         self._sys_mem_config = SystemMemControllerConfig(
-            memory_size=sys_mem_size,
-            memory_filename=f"sys-mem{port_index}.bin",
+            memory_size=config.sys_mem_size,
+            memory_filename=f"sys-mem{config.port_index}.bin",
         )
         self._irq_manager = IrqManager(
             device_name=host_name,
-            addr=irq_host,
-            port=irq_port,
+            addr=config.irq_host,
+            port=config.irq_port,
             server=True,
-            device_id=port_index,
+            device_id=config.port_index,
         )
         self._cxl_memory_hub_config = CxlMemoryHubConfig(
             host_name=host_name,
-            root_bus=port_index,
+            root_bus=config.port_index,
             root_port_switch_type=ROOT_PORT_SWITCH_TYPE.PASS_THROUGH,
             root_ports=root_ports,
             sys_mem_controller=self._sys_mem_config,
             irq_handler=self._irq_manager,
         )
         self._cxl_memory_hub = CxlMemoryHub(self._cxl_memory_hub_config)
-        self._cpu = CPU(self._cxl_memory_hub, sys_sw_app, user_app)
+        self._cpu = CPU(self._cxl_memory_hub, config.sys_sw_app, config.user_app)
 
-        self._enable_hm = enable_hm
+        self._enable_hm = config.enable_hm
         if self._enable_hm:
             methods = {
                 "HOST:CXL_HOST_READ": self._cxl_host_read,
                 "HOST:CXL_HOST_WRITE": self._cxl_host_write,
             }
             self._host_mgr_conn_client = HostMgrConnClient(
-                port_index=port_index,
-                host=host_conn_host,
-                port=host_conn_port,
+                port_index=config.port_index,
+                host=config.host_conn_host,
+                port=config.host_conn_port,
                 methods=methods,
             )
 

--- a/opencis/cxl/component/cxl_host.py
+++ b/opencis/cxl/component/cxl_host.py
@@ -103,31 +103,19 @@ class CxlHost(RunnableComponent):
         tasks = [
             await self._irq_manager.run_wait_ready(),
             await self._cxl_memory_hub.run_wait_ready(),
+            await self._cpu.run_wait_ready(),
         ]
-        t = asyncio.create_task(self._cpu.run())
-        await self._cpu.wait_for_ready()
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
         if self._enable_hm:
             tasks.append(asyncio.create_task(self._host_mgr_conn_client.run()))
             await self._host_mgr_conn_client.wait_for_ready()
 
         await self._change_status_to_running()
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
-        logger.info(f"{tasks}")
         await asyncio.gather(*tasks)
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
-        await t
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
 
     async def _stop(self):
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
-        t1 = asyncio.create_task(self._cxl_memory_hub.stop())
-        t2 = asyncio.create_task(self._cpu.stop())
-        t3 = asyncio.create_task(self._irq_manager.stop())
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
-        await t1
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
-        await t3
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
-        await t2
-        logger.info(f"File: {__file__}, Line: {inspect.currentframe().f_lineno}")
+        tasks = [
+            asyncio.create_task(self._cxl_memory_hub.stop()),
+            asyncio.create_task(self._cpu.stop()),
+            asyncio.create_task(self._irq_manager.stop()),
+        ]
+        await asyncio.gather(*tasks)

--- a/opencis/cxl/component/cxl_memory_hub.py
+++ b/opencis/cxl/component/cxl_memory_hub.py
@@ -8,6 +8,8 @@
 import asyncio
 from dataclasses import dataclass, field
 from typing import Callable, List
+
+from opencis.util.logger import logger
 from opencis.cxl.component.irq_manager import Irq, IrqManager
 from opencis.util.component import RunnableComponent
 from opencis.cxl.component.root_complex.root_complex import (

--- a/opencis/cxl/component/cxl_memory_hub.py
+++ b/opencis/cxl/component/cxl_memory_hub.py
@@ -9,7 +9,6 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Callable, List
 
-from opencis.util.logger import logger
 from opencis.cxl.component.irq_manager import Irq, IrqManager
 from opencis.util.component import RunnableComponent
 from opencis.cxl.component.root_complex.root_complex import (

--- a/opencis/cxl/component/hdm_decoder.py
+++ b/opencis/cxl/component/hdm_decoder.py
@@ -174,6 +174,9 @@ class HdmDecoderManagerBase(LabeledComponent):
 
     def get_decoder_from_hpa(self, hpa: int) -> Optional[HdmDecoderBase]:
         for decoder in self._decoders:
+            logger.debug(
+                f"decoder.index:{decoder.index}, decoder.base:{decoder.base:x}, decoder.size:{decoder.size:x}, decoder.ig:{decoder.ig:x}, decoder.iw:{decoder.iw:x}"
+            )
             if decoder.is_hpa_in_range(hpa):
                 return decoder
         return None

--- a/opencis/cxl/component/hdm_decoder.py
+++ b/opencis/cxl/component/hdm_decoder.py
@@ -175,7 +175,8 @@ class HdmDecoderManagerBase(LabeledComponent):
     def get_decoder_from_hpa(self, hpa: int) -> Optional[HdmDecoderBase]:
         for decoder in self._decoders:
             logger.debug(
-                f"decoder.index:{decoder.index}, decoder.base:{decoder.base:x}, decoder.size:{decoder.size:x}, decoder.ig:{decoder.ig:x}, decoder.iw:{decoder.iw:x}"
+                f"decoder.index:{decoder.index}, decoder.base:{decoder.base:x}"
+                f"decoder.size:{decoder.size:x}, decoder.ig/iw:{decoder.ig:x}/{decoder.iw:x}"
             )
             if decoder.is_hpa_in_range(hpa):
                 return decoder

--- a/opencis/drivers/cxl_mem_driver.py
+++ b/opencis/drivers/cxl_mem_driver.py
@@ -83,3 +83,61 @@ class CxlMemDriver(LabeledComponent):
             logger.warning(self._create_message(f"Failed to configure HDM decoder of {bdf_str}"))
             return False
         return True
+
+    async def config_single_mem_device(
+        self,
+        device: CxlDeviceInfo,
+        hpa_base: int,
+        total_size: int,
+        ig: INTERLEAVE_GRANULARITY = INTERLEAVE_GRANULARITY.SIZE_256B,
+        iw: INTERLEAVE_WAYS = INTERLEAVE_WAYS.WAY_1,
+    ) -> bool:
+        device.log_prefix = "CxlMemDriver"
+        successful = await device.configure_hdm_decoder_device(
+            hpa_base=hpa_base,
+            hpa_size=total_size,
+            interleaving_granularity=ig.value,
+            interleaving_way=iw.value,
+        )
+        if not successful:
+            bdf_str = device.pci_device_info.get_bdf_string()
+            logger.warning(self._create_message(f"Failed to configure HDM decoder of {bdf_str}"))
+            return False
+
+        port_number = self.get_port_number(device)
+        if port_number < 0:
+            return False
+        return True
+
+    async def config_usp(
+        self,
+        device: CxlDeviceInfo,
+        hpa_base: int,
+        size: int,
+        ig: INTERLEAVE_GRANULARITY = INTERLEAVE_GRANULARITY.SIZE_256B,
+        iw: INTERLEAVE_WAYS = INTERLEAVE_WAYS.WAY_1,
+    ) -> bool:
+        downstream_port = device.parent
+        port_number = self.get_port_number(device)
+        if port_number < 0:
+            return False
+
+        upstream_port = downstream_port.parent
+        upstream_port.log_prefix = "CxlMemDriver"
+        if not upstream_port.is_upstream_port():
+            bdf_str = upstream_port.pci_device_info.get_bdf_string()
+            logger.warning(self._create_message(f"{bdf_str} is not upstream port"))
+            return False
+
+        successful = await upstream_port.configure_hdm_decoder_switch(
+            hpa_base=hpa_base,
+            hpa_size=size,
+            target_list=[1, 2, 3, 4],
+            interleaving_granularity=0,
+            interleaving_way=2,
+        )
+        if not successful:
+            bdf_str = device.pci_device_info.get_bdf_string()
+            logger.warning(self._create_message(f"Failed to configure HDM decoder of {bdf_str}"))
+            return False
+        return True

--- a/opencis/drivers/cxl_mem_driver.py
+++ b/opencis/drivers/cxl_mem_driver.py
@@ -46,46 +46,32 @@ class CxlMemDriver(LabeledComponent):
     async def attach_single_mem_device(
         self, device: CxlDeviceInfo, hpa_base: int, size: int
     ) -> bool:
-        device.log_prefix = "CxlMemDriver"
-        successful = await device.configure_hdm_decoder_device(hpa_base=hpa_base, hpa_size=size)
+        # should only be used for non-interleave setup
+        successful = await self.config_cxl_mem_device(device, hpa_base, size)
         if not successful:
-            bdf_str = device.pci_device_info.get_bdf_string()
-            logger.warning(self._create_message(f"Failed to configure HDM decoder of {bdf_str}"))
             return False
 
-        downstream_port = device.parent
+        downsream_port = device.parent
+        upstream_port = downsream_port.parent
         port_number = self.get_port_number(device)
-        if port_number < 0:
-            return False
-
-        upstream_port = downstream_port.parent
-        upstream_port.log_prefix = "CxlMemDriver"
-        if not upstream_port.is_upstream_port():
-            bdf_str = upstream_port.pci_device_info.get_bdf_string()
-            logger.warning(self._create_message(f"{bdf_str} is not upstream port"))
-            return False
-
-        successful = await upstream_port.configure_hdm_decoder_switch(
-            hpa_base=hpa_base, hpa_size=size, target_list=[port_number]
-        )
+        successful = await self.config_usp(upstream_port, hpa_base, size, [port_number])
         if not successful:
-            bdf_str = device.pci_device_info.get_bdf_string()
-            logger.warning(self._create_message(f"Failed to configure HDM decoder of {bdf_str}"))
             return False
+
         return True
 
-    async def config_single_mem_device(
+    async def config_cxl_mem_device(
         self,
         device: CxlDeviceInfo,
         hpa_base: int,
-        total_size: int,
+        size: int,
         ig: INTERLEAVE_GRANULARITY = INTERLEAVE_GRANULARITY.SIZE_256B,
         iw: INTERLEAVE_WAYS = INTERLEAVE_WAYS.WAY_1,
     ) -> bool:
         device.log_prefix = "CxlMemDriver"
         successful = await device.configure_hdm_decoder_device(
             hpa_base=hpa_base,
-            hpa_size=total_size,
+            hpa_size=size,
             interleaving_granularity=ig.value,
             interleaving_way=iw.value,
         )

--- a/opencis/drivers/cxl_mem_driver.py
+++ b/opencis/drivers/cxl_mem_driver.py
@@ -1,13 +1,15 @@
 """
- Copyright (c) 2024, Eeum, Inc.
+Copyright (c) 2024, Eeum, Inc.
 
- This software is licensed under the terms of the Revised BSD License.
- See LICENSE for details.
+This software is licensed under the terms of the Revised BSD License.
+See LICENSE for details.
 """
 
 from typing import List
+
 from opencis.util.component import LabeledComponent, Label
 from opencis.cxl.component.root_complex.root_complex import RootComplex
+from opencis.cxl.component.hdm_decoder import INTERLEAVE_GRANULARITY, INTERLEAVE_WAYS
 from opencis.drivers.cxl_bus_driver import CxlBusDriver, CxlDeviceInfo
 from opencis.util.logger import logger
 
@@ -42,10 +44,20 @@ class CxlMemDriver(LabeledComponent):
         return downstream_port.pci_device_info.get_port_number()
 
     async def attach_single_mem_device(
-        self, device: CxlDeviceInfo, hpa_base: int, size: int
+        self,
+        device: CxlDeviceInfo,
+        hpa_base: int,
+        size: int,
+        ig: INTERLEAVE_GRANULARITY = INTERLEAVE_GRANULARITY.SIZE_256B,
+        iw: INTERLEAVE_WAYS = INTERLEAVE_WAYS.WAY_1,
     ) -> bool:
         device.log_prefix = "CxlMemDriver"
-        successful = await device.configure_hdm_decoder_device(hpa_base=hpa_base, hpa_size=size)
+        successful = await device.configure_hdm_decoder_device(
+            hpa_base=hpa_base,
+            hpa_size=size,
+            interleaving_granularity=ig.value,
+            interleaving_way=iw.value,
+        )
         if not successful:
             bdf_str = device.pci_device_info.get_bdf_string()
             logger.warning(self._create_message(f"Failed to configure HDM decoder of {bdf_str}"))

--- a/opencis/drivers/cxl_mem_driver.py
+++ b/opencis/drivers/cxl_mem_driver.py
@@ -1,8 +1,8 @@
 """
-Copyright (c) 2024, Eeum, Inc.
+ Copyright (c) 2024, Eeum, Inc.
 
-This software is licensed under the terms of the Revised BSD License.
-See LICENSE for details.
+ This software is licensed under the terms of the Revised BSD License.
+ See LICENSE for details.
 """
 
 from typing import List
@@ -111,18 +111,13 @@ class CxlMemDriver(LabeledComponent):
 
     async def config_usp(
         self,
-        device: CxlDeviceInfo,
+        upstream_port: CxlDeviceInfo,
         hpa_base: int,
         size: int,
+        target_list: list[int],
         ig: INTERLEAVE_GRANULARITY = INTERLEAVE_GRANULARITY.SIZE_256B,
         iw: INTERLEAVE_WAYS = INTERLEAVE_WAYS.WAY_1,
     ) -> bool:
-        downstream_port = device.parent
-        port_number = self.get_port_number(device)
-        if port_number < 0:
-            return False
-
-        upstream_port = downstream_port.parent
         upstream_port.log_prefix = "CxlMemDriver"
         if not upstream_port.is_upstream_port():
             bdf_str = upstream_port.pci_device_info.get_bdf_string()
@@ -132,12 +127,12 @@ class CxlMemDriver(LabeledComponent):
         successful = await upstream_port.configure_hdm_decoder_switch(
             hpa_base=hpa_base,
             hpa_size=size,
-            target_list=[1, 2, 3, 4],
-            interleaving_granularity=0,
-            interleaving_way=2,
+            target_list=target_list,
+            interleaving_granularity=ig.value,
+            interleaving_way=iw.value,
         )
         if not successful:
-            bdf_str = device.pci_device_info.get_bdf_string()
+            bdf_str = upstream_port.pci_device_info.get_bdf_string()
             logger.warning(self._create_message(f"Failed to configure HDM decoder of {bdf_str}"))
             return False
         return True

--- a/opencis/drivers/cxl_mem_driver.py
+++ b/opencis/drivers/cxl_mem_driver.py
@@ -44,20 +44,10 @@ class CxlMemDriver(LabeledComponent):
         return downstream_port.pci_device_info.get_port_number()
 
     async def attach_single_mem_device(
-        self,
-        device: CxlDeviceInfo,
-        hpa_base: int,
-        size: int,
-        ig: INTERLEAVE_GRANULARITY = INTERLEAVE_GRANULARITY.SIZE_256B,
-        iw: INTERLEAVE_WAYS = INTERLEAVE_WAYS.WAY_1,
+        self, device: CxlDeviceInfo, hpa_base: int, size: int
     ) -> bool:
         device.log_prefix = "CxlMemDriver"
-        successful = await device.configure_hdm_decoder_device(
-            hpa_base=hpa_base,
-            hpa_size=size,
-            interleaving_granularity=ig.value,
-            interleaving_way=iw.value,
-        )
+        successful = await device.configure_hdm_decoder_device(hpa_base=hpa_base, hpa_size=size)
         if not successful:
             bdf_str = device.pci_device_info.get_bdf_string()
             logger.warning(self._create_message(f"Failed to configure HDM decoder of {bdf_str}"))

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -22,7 +22,7 @@ from opencis.cxl.transport.transaction import (
 )
 from opencis.apps.fabric_manager import CxlFabricManager
 from opencis.apps.memory_pooling import my_sys_sw_app, sample_app
-from opencis.cxl.component.cxl_host import CxlHost
+from opencis.cxl.component.cxl_host import CxlHost, CxlHostConfig
 from opencis.cxl.component.host_manager import HostManager, UtilConnClient
 from opencis.cxl.component.switch_connection_manager import SwitchConnectionManager
 from opencis.cxl.component.cxl_component import PortConfig, PORT_TYPE
@@ -322,16 +322,19 @@ async def test_cxl_host_type3_ete():
     # host_fm_conn_port port number conflict?
     fabric_manager = CxlFabricManager(mctp_port=mctp_port, host_fm_conn_port=8700)
     host_manager = HostManager(host_port=host_port, util_port=util_port)
-    host = CxlHost(
+    ig = 0
+    iw = 4
+    cxl_host_config = CxlHostConfig(
         port_index=0,
         sys_mem_size=(16 * MB),
-        sys_sw_app=my_sys_sw_app,
+        sys_sw_app=lambda **kwargs: my_sys_sw_app(ig=ig, iw=iw, **kwargs),
         user_app=sample_app,
         switch_port=switch_port,
         irq_port=irq_port,
         host_conn_port=host_port,
         enable_hm=False,
     )
+    host = CxlHost(cxl_host_config)
     start_tasks = [
         await fabric_manager.run_wait_ready(),
         await sw_conn_manager.run_wait_ready(),

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -322,8 +322,9 @@ async def test_cxl_host_type3_ete():
     # host_fm_conn_port port number conflict?
     fabric_manager = CxlFabricManager(mctp_port=mctp_port, host_fm_conn_port=8700)
     host_manager = HostManager(host_port=host_port, util_port=util_port)
+
     ig = 0
-    iw = 4
+    iw = 2
     cxl_host_config = CxlHostConfig(
         port_index=0,
         sys_mem_size=(16 * MB),

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -331,7 +331,7 @@ async def test_cxl_host_type3_ete():
         port_index=0,
         sys_mem_size=(16 * MB),
         sys_sw_app=lambda **kwargs: my_sys_sw_app(ig=ig, iw=iw, **kwargs),
-        user_app=sample_app,
+        user_app=lambda **kwargs: sample_app(keepalive=False, **kwargs),
         switch_port=switch_port,
         irq_port=irq_port,
         host_conn_port=host_port,

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -323,8 +323,10 @@ async def test_cxl_host_type3_ete():
     fabric_manager = CxlFabricManager(mctp_port=mctp_port, host_fm_conn_port=8700)
     host_manager = HostManager(host_port=host_port, util_port=util_port)
 
+    # 256B / 4-ways
     ig = 0
     iw = 2
+
     cxl_host_config = CxlHostConfig(
         port_index=0,
         sys_mem_size=(16 * MB),

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -323,9 +323,9 @@ async def test_cxl_host_type3_ete():
     fabric_manager = CxlFabricManager(mctp_port=mctp_port, host_fm_conn_port=8700)
     host_manager = HostManager(host_port=host_port, util_port=util_port)
 
-    # 256B / 4-ways
+    # 256B / No interleave
     ig = 0
-    iw = 2
+    iw = 0
 
     cxl_host_config = CxlHostConfig(
         port_index=0,


### PR DESCRIPTION
Usage:
```
# 256B granularity, 4-way interleave
./cxl-util start <...> --ig 0 --iw 2
```
`ig` and `iw` values are found in the CXL specification document. The integer values show below for reference.
```
class INTERLEAVE_GRANULARITY(IntEnum):
    SIZE_256B = 0x0
    SIZE_512B = 0x1
    SIZE_1KB = 0x2
    SIZE_2KB = 0x3
    SIZE_4KB = 0x4
    SIZE_8KB = 0x5
    SIZE_16KB = 0x6

class INTERLEAVE_WAYS(IntEnum):
    WAY_1 = 0x0
    WAY_2 = 0x1
    WAY_4 = 0x2
    WAY_8 = 0x3
    WAY_16 = 0x4
    WAY_3 = 0x8
    WAY_6 = 0x9
    WAY_12 = 0xA
```
