### PR TITLE
Centralize mem.bin name creation and ensure uniqueness

### DIFF
--- a/opencis/util/memory.py
+++ b/opencis/util/memory.py
@@ -1,0 +1,37 @@
+"""
+ Copyright (c) 2025, Eeum, Inc.
+
+ This software is licensed under the terms of the Revised BSD License.
+ See LICENSE for details.
+"""
+
+import atexit
+from functools import partial
+import os
+import sys
+
+
+def get_memory_bin_name(index_primary: int = 0, index_secondary: int = -1) -> str:
+    def cleanup(path):
+        try:
+            os.remove(path)
+        except Exception:
+            pass
+
+    # Get caller function name
+    # pylint: disable=protected-access
+    func_name = sys._getframe(1).f_code.co_name
+
+    while True:
+        if index_secondary != -1:
+            bin_name = f"mem_{func_name}_{index_primary}-{index_secondary}.bin"
+        else:
+            bin_name = f"mem_{func_name}_{index_primary}.bin"
+        # Check if the bin name already exists
+        if not os.path.exists(bin_name):
+            break
+        index_primary += 1
+
+    # Make sure we remove it upon exit
+    atexit.register(partial(cleanup, bin_name))
+    return bin_name

--- a/tests/test_cxl_component_switch_bind.py
+++ b/tests/test_cxl_component_switch_bind.py
@@ -16,6 +16,7 @@ from opencis.cxl.device.downstream_port_device import DownstreamPortDevice
 from opencis.cxl.device.upstream_port_device import UpstreamPortDevice
 from opencis.cxl.device.pci_to_pci_bridge_device import PpbDevice
 from opencis.cxl.component.virtual_switch_manager import CxlVirtualSwitch
+from opencis.util.memory import get_memory_bin_name
 from opencis.util.number_const import MB
 from opencis.util.unaligned_bit_structure import UnalignedBitStructure
 
@@ -78,7 +79,7 @@ async def test_single_logical_device_bind_unbind():
     )
 
     memory_size = 256 * MB
-    memory_file = "mem.bin"
+    memory_file = get_memory_bin_name()
     device = SingleLogicalDevice(
         memory_size=memory_size,
         memory_file=memory_file,
@@ -189,7 +190,12 @@ async def test_multi_logical_device_bind_unbind():
     )
 
     memory_sizes = [256 * MB, 256 * MB, 256 * MB, 256 * MB]
-    memory_files = ["mem1.bin", "mem2.bin", "mem3.bin", "mem4.bin"]
+    memory_files = [
+        get_memory_bin_name(1),
+        get_memory_bin_name(2),
+        get_memory_bin_name(3),
+        get_memory_bin_name(4),
+    ]
     device = MultiLogicalDevice(
         memory_sizes=memory_sizes,
         memory_files=memory_files,

--- a/tests/test_cxl_component_virtual_switch.py
+++ b/tests/test_cxl_component_virtual_switch.py
@@ -25,6 +25,7 @@ from opencis.cxl.device.cxl_type3_device import CxlType3Device, CXL_T3_DEV_TYPE
 from opencis.cxl.component.virtual_switch_manager import (
     CxlVirtualSwitch,
 )
+from opencis.util.memory import get_memory_bin_name
 from opencis.util.unaligned_bit_structure import UnalignedBitStructure
 from opencis.cxl.transport.transaction import (
     CXL_MEM_M2SBIRSP_OPCODE,
@@ -91,7 +92,7 @@ def create_cxl_topology(bind: bool = False, memory_size: int = 0x100000) -> Tupl
         sld = CxlType3Device(
             transport_connection=connection,
             memory_size=memory_size,
-            memory_file=f"mem{port_index}.bin",
+            memory_file=get_memory_bin_name(port_index),
             serial_number="EEEEEEEEEEEEEEEE",
             dev_type=CXL_T3_DEV_TYPE.SLD,
         )

--- a/tests/test_cxl_device_multiheaded_single_logical_device.py
+++ b/tests/test_cxl_device_multiheaded_single_logical_device.py
@@ -11,6 +11,7 @@ import pytest
 from opencis.apps.multiheaded_single_logical_device import MultiHeadedSingleLogicalDevice
 from opencis.cxl.device.root_port_device import CxlRootPortDevice
 from opencis.cxl.component.cxl_connection import CxlConnection
+from opencis.util.memory import get_memory_bin_name
 from opencis.util.number_const import MB
 
 # Test with 4 ports
@@ -19,7 +20,7 @@ num_ports = 4
 
 def test_multiheaded_single_logical_device():
     memory_size = 256 * MB
-    memory_file = "mem.bin"
+    memory_file = get_memory_bin_name()
     transport_connection = CxlConnection()
     MultiHeadedSingleLogicalDevice(
         num_ports,
@@ -34,7 +35,7 @@ def test_multiheaded_single_logical_device():
 @pytest.mark.asyncio
 async def test_multiheaded_single_logical_device_run_stop(get_gold_std_reg_vals):
     memory_size = 256 * MB
-    memory_file = "mem.bin"
+    memory_file = get_memory_bin_name()
     transport_connection = CxlConnection()
     mhsld_device = MultiHeadedSingleLogicalDevice(
         num_ports,
@@ -62,7 +63,7 @@ async def test_multiheaded_single_logical_device_run_stop(get_gold_std_reg_vals)
 @pytest.mark.asyncio
 async def test_multiheaded_single_logical_device_enumeration():
     memory_size = 256 * MB
-    memory_file = "mem.bin"
+    memory_file = get_memory_bin_name()
     transport_connection = CxlConnection()
     root_port_device = CxlRootPortDevice(downstream_connection=transport_connection, label="Port0")
     mhsld_device = MultiHeadedSingleLogicalDevice(

--- a/tests/test_cxl_device_single_logical_device.py
+++ b/tests/test_cxl_device_single_logical_device.py
@@ -11,6 +11,7 @@ import pytest
 from opencis.apps.single_logical_device import SingleLogicalDevice
 from opencis.cxl.device.root_port_device import CxlRootPortDevice
 from opencis.cxl.component.cxl_connection import CxlConnection
+from opencis.util.memory import get_memory_bin_name
 from opencis.util.number_const import MB
 
 # This test will cause many duplicate code between MH-SLD, disable duplicate-code lint here
@@ -19,7 +20,7 @@ from opencis.util.number_const import MB
 
 def test_single_logical_device():
     memory_size = 256 * MB
-    memory_file = "mem.bin"
+    memory_file = get_memory_bin_name()
     transport_connection = CxlConnection()
     SingleLogicalDevice(
         memory_size=memory_size,
@@ -33,7 +34,7 @@ def test_single_logical_device():
 @pytest.mark.asyncio
 async def test_single_logical_device_run_stop(get_gold_std_reg_vals):
     memory_size = 256 * MB
-    memory_file = "mem.bin"
+    memory_file = get_memory_bin_name()
     transport_connection = CxlConnection()
     device = SingleLogicalDevice(
         memory_size=memory_size,
@@ -59,7 +60,7 @@ async def test_single_logical_device_run_stop(get_gold_std_reg_vals):
 @pytest.mark.asyncio
 async def test_single_logical_device_enumeration():
     memory_size = 256 * MB
-    memory_file = "mem.bin"
+    memory_file = get_memory_bin_name()
     transport_connection = CxlConnection()
     root_port_device = CxlRootPortDevice(downstream_connection=transport_connection, label="Port0")
     device = SingleLogicalDevice(

--- a/tests/test_cxl_device_type2_device.py
+++ b/tests/test_cxl_device_type2_device.py
@@ -15,6 +15,7 @@ from opencis.cxl.device.cxl_type2_device import (
 )
 from opencis.cxl.device.root_port_device import CxlRootPortDevice
 from opencis.cxl.component.cxl_connection import CxlConnection
+from opencis.util.memory import get_memory_bin_name
 from opencis.util.number_const import MB
 
 
@@ -23,7 +24,7 @@ def test_type2_device():
         device_name="CXLType2Device",
         transport_connection=CxlConnection(),
         memory_size=256 * MB,
-        memory_file="mem.bin",
+        memory_file=get_memory_bin_name(),
     )
     CxlType2Device(device_config)
 
@@ -34,7 +35,7 @@ async def test_type2_device_run_stop(get_gold_std_reg_vals):
         device_name="CXLType2Device",
         transport_connection=CxlConnection(),
         memory_size=256 * MB,
-        memory_file="mem.bin",
+        memory_file=get_memory_bin_name(),
     )
     device = CxlType2Device(device_config)
 
@@ -58,7 +59,7 @@ async def test_type2_device_enumeration():
         device_name="CXLType2Device",
         transport_connection=transport_connection,
         memory_size=256 * MB,
-        memory_file="mem.bin",
+        memory_file=get_memory_bin_name(),
     )
     root_port_device = CxlRootPortDevice(downstream_connection=transport_connection, label="Port0")
     device = CxlType2Device(device_config)

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -32,6 +32,7 @@ from opencis.cxl.environment import parse_cxl_environment
 from opencis.apps.cxl_switch import CxlSwitch
 from opencis.apps.single_logical_device import SingleLogicalDevice
 from opencis.apps.packet_trace_runner import PacketTraceRunner
+from opencis.util.memory import get_memory_bin_name
 from opencis.util.number_const import MB
 from opencis.util.number import get_rand_range_generator
 
@@ -314,7 +315,7 @@ async def test_cxl_host_type3_ete():
     sld = SingleLogicalDevice(
         port_index=1,
         memory_size=0x1000000,
-        memory_file=f"mem{switch_port}.bin",
+        memory_file=get_memory_bin_name(switch_port),
         serial_number="DDDDDDDDDDDDDDDD",
         port=switch_port,
     )
@@ -396,7 +397,7 @@ async def test_cxl_qemu_host_type3():
         sld = SingleLogicalDevice(
             port_index=config.port_index,
             memory_size=config.memory_size,
-            memory_file=f"mem{switch_port}-{i}.bin",
+            memory_file=get_memory_bin_name(switch_port, i),
             serial_number=config.serial_number,
             host=env.switch_config.host,
             port=env.switch_config.port,


### PR DESCRIPTION
Accidentally creating the same mem.bin name will crash the tests.

While at it, remove the binary at exit so that the project root directory is not churned.