### PR TITLE
Make sure clients are closed before the server

### DIFF
--- a/tests/test_cxl_device_multi_logical_device.py
+++ b/tests/test_cxl_device_multi_logical_device.py
@@ -384,5 +384,7 @@ async def test_multi_logical_device_ld_id():
     await mld_task
 
     # Stop pseudo server
+    mld_pseudo_server_writer.close()
+    await mld_pseudo_server_writer.wait_closed()
     server.close()
     await server.wait_closed()

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -625,5 +625,7 @@ async def test_multi_logical_device_ld_id():
     await mld_task
 
     # Stop pseudo server
+    mld_pseudo_server_writer.close()
+    await mld_pseudo_server_writer.wait_closed()
     server.close()
     await server.wait_closed()


### PR DESCRIPTION
await port.packet_processor.stop() is no longer required after manually closing the transport.

Python 3.13 has an API to do this automatically, but we want to maintain Python 3.11 compatibility.

Related: https://github.com/python/cpython/issues/104344
Fixes: https://github.com/opencis/opencis/issues/95