### PR TITLE
Increase pytest timeout to 45s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ build-backend = "pdm.backend"
 
 [tool.pytest.ini_options]
 testpaths = "tests/"
-timeout = 30
+timeout = 45
 filterwarnings = [
   "ignore::DeprecationWarning"
 ]


### PR DESCRIPTION
tests/test_cxl_host.py::test_cxl_qemu_host_type3 runs very long.