### PR TITLE
Avoid attaching objects to master pytest object

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,5 +39,5 @@ class TEST_PORT(IntEnum):
     TEST_14 = auto()
 
 
-def pytest_configure():
-    pytest.PORT = TEST_PORT
+def pytest_configure(config):
+    config.PORT = TEST_PORT

--- a/tests/test_cxl_component_switch_bind.py
+++ b/tests/test_cxl_component_switch_bind.py
@@ -23,7 +23,7 @@ from opencis.util.unaligned_bit_structure import UnalignedBitStructure
 # test_single_logical_device_bind_unbind() and test_multi_logical_device_bind_unbind() are similar
 # pylint: disable=duplicate-code
 @pytest.mark.asyncio
-async def test_single_logical_device_bind_unbind():
+async def test_single_logical_device_bind_unbind(request):
     # Connection between switch and device
     transport_connection = CxlConnection()
 
@@ -73,7 +73,7 @@ async def test_single_logical_device_bind_unbind():
         vppb_counts=vppb_counts,
         initial_bounds=initial_bounds,
         physical_ports=physical_ports,
-        irq_port=8500 + pytest.PORT.TEST_1,
+        irq_port=8500 + request.config.PORT.TEST_1,
         allocated_ld=allocated_ld,
     )
 
@@ -133,7 +133,7 @@ async def test_single_logical_device_bind_unbind():
 # test_single_logical_device_bind_unbind() and test_multi_logical_device_bind_unbind() are similar
 # pylint: disable=duplicate-code
 @pytest.mark.asyncio
-async def test_multi_logical_device_bind_unbind():
+async def test_multi_logical_device_bind_unbind(request):
     # Connection between switch and device
     transport_connection = CxlConnection()
 
@@ -184,7 +184,7 @@ async def test_multi_logical_device_bind_unbind():
         vppb_counts=vppb_counts,
         initial_bounds=initial_bounds,
         physical_ports=physical_ports,
-        irq_port=8500 + pytest.PORT.TEST_1,
+        irq_port=8500 + request.config.PORT.TEST_1,
         allocated_ld=allocated_ld,
     )
 

--- a/tests/test_cxl_component_virtual_switch.py
+++ b/tests/test_cxl_component_virtual_switch.py
@@ -183,7 +183,7 @@ def test_virtual_switch_manager_init():
 
 
 @pytest.mark.asyncio
-async def test_virtual_switch_manager_run_and_stop():
+async def test_virtual_switch_manager_run_and_stop(request):
     UnalignedBitStructure.make_quiet()
 
     vcs_id = 0
@@ -228,7 +228,7 @@ async def test_virtual_switch_manager_run_and_stop():
         vppb_counts=vppb_counts,
         initial_bounds=initial_bounds,
         physical_ports=physical_ports,
-        irq_port=8500 + pytest.PORT.TEST_1,
+        irq_port=8500 + request.config.PORT.TEST_1,
         allocated_ld=allocated_ld,
     )
 


### PR DESCRIPTION
Latest pylint complains:

tests/test_cxl_component_switch_bind.py:76:24: E1101: Module 'pytest' has no 'PORT' member (no-member)
tests/test_cxl_component_switch_bind.py:187:24: E1101: Module 'pytest' has no 'PORT' member (no-member)