### PR TITLE
Centralize asyncio servers and ask kernel for ephemeral port when run…

### DIFF
--- a/opencis/apps/cxl_switch.py
+++ b/opencis/apps/cxl_switch.py
@@ -190,3 +190,6 @@ class CxlSwitch(RunnableComponent):
             stop_tasks.append(create_task(self._mctp_connection_client.stop()))
             stop_tasks.append(create_task(self._mctp_cci_executor.stop()))
         await gather(*stop_tasks)
+
+    def get_port(self):
+        return self._switch_connection_manager.get_port()

--- a/opencis/apps/cxl_switch.py
+++ b/opencis/apps/cxl_switch.py
@@ -123,6 +123,9 @@ class CxlSwitch(RunnableComponent):
 
         self._run_as_child = switch_config.run_as_child
 
+    def get_port(self):
+        return self._switch_connection_manager.get_port()
+
     def _initialize_mctp_endpoint(self):
         ident_payload = IdentifyResponsePayload(
             device_id=SW_SWITCH_DID, component_type=IdentifyComponentType.SWITCH
@@ -190,6 +193,3 @@ class CxlSwitch(RunnableComponent):
             stop_tasks.append(create_task(self._mctp_connection_client.stop()))
             stop_tasks.append(create_task(self._mctp_cci_executor.stop()))
         await gather(*stop_tasks)
-
-    def get_port(self):
-        return self._switch_connection_manager.get_port()

--- a/opencis/apps/fabric_manager.py
+++ b/opencis/apps/fabric_manager.py
@@ -52,6 +52,9 @@ class CxlFabricManager(RunnableComponent):
         self._host_fm_conn_server.register_general_handler(HostFMMsg.CONFIRM, self._host_callback())
         self._use_test_runner = use_test_runner
 
+    def get_host_fm_port(self):
+        return self._host_fm_conn_server.get_port()
+
     def _host_callback(self):
         async def _func(_: int, data: HostFMMsg):
             print(f"Received {data.readable} from host (root port={data.root_port})")
@@ -117,6 +120,3 @@ class CxlFabricManager(RunnableComponent):
         await self._connection_manager.stop()
         await self._socketio_server.stop()
         await self._api_client.stop()
-
-    def get_host_fm_port(self):
-        return self._host_fm_conn_server.get_port()

--- a/opencis/apps/fabric_manager.py
+++ b/opencis/apps/fabric_manager.py
@@ -117,3 +117,6 @@ class CxlFabricManager(RunnableComponent):
         await self._connection_manager.stop()
         await self._socketio_server.stop()
         await self._api_client.stop()
+
+    def get_host_fm_port(self):
+        return self._host_fm_conn_server.get_port()

--- a/opencis/apps/memory_pooling.py
+++ b/opencis/apps/memory_pooling.py
@@ -74,7 +74,7 @@ class MemoryBaseTracker:
 host_fm_conn = None
 
 
-async def my_sys_sw_app(ig: int = None, iw: int = None, **kwargs):
+async def my_sys_sw_app(ig: int = None, iw: int = None, host_fm_conn_port: int = 8700, **kwargs):
     cxl_memory_hub: CxlMemoryHub
 
     # Max addr for CFG is 0x9FFFFFFF, given max num bus = 8
@@ -90,7 +90,12 @@ async def my_sys_sw_app(ig: int = None, iw: int = None, **kwargs):
     root_complex = cxl_memory_hub.get_root_complex()
     root_port = cxl_memory_hub.get_root_port()
     host_fm_conn_client = ShortMsgConn(
-        "FM_Client", port=8700, server=False, msg_width=16, msg_type=HostFMMsg, device_id=root_port
+        "FM_Client",
+        port=host_fm_conn_port,
+        server=False,
+        msg_width=16,
+        msg_type=HostFMMsg,
+        device_id=root_port,
     )
     # pylint: disable=global-statement
     global host_fm_conn  # To prevent the connection from GC'ed after function's done

--- a/opencis/cxl/component/host_manager.py
+++ b/opencis/cxl/component/host_manager.py
@@ -58,6 +58,8 @@ class HostMgrConnServer(RunnableComponent):
     async def serve(self):
         self._fut = asyncio.Future()
         self._host_server = await websockets.serve(self._serve, self._host, self._port)
+        if self._port == 0:
+            self._port = self._host_server.sockets[0].getsockname()[1]
         await self._change_status_to_running()
         res = await self._fut
         logger.debug(self._create_message(f"{res}"))
@@ -72,6 +74,9 @@ class HostMgrConnServer(RunnableComponent):
         self._fut.set_result("Host Done")
         self._host_server.close()
         await self._host_server.wait_closed()
+
+    def get_port(self):
+        return self._port
 
 
 class HostMgrConnClient(RunnableComponent):
@@ -184,6 +189,8 @@ class UtilConnServer(RunnableComponent):
     async def serve(self):
         self._fut = asyncio.Future()
         self._util_server = await websockets.serve(self._serve, self._host, self._port)
+        if self._port == 0:
+            self._port = self._util_server.sockets[0].getsockname()[1]
         await self._change_status_to_running()
         res = await self._fut
         logger.debug(self._create_message(f"{res}"))
@@ -198,6 +205,9 @@ class UtilConnServer(RunnableComponent):
         self._fut.set_result("Host Done")
         self._util_server.close()
         await self._util_server.wait_closed()
+
+    def get_port(self):
+        return self._port
 
 
 class UtilConnClient:
@@ -268,3 +278,9 @@ class HostManager(RunnableComponent):
             asyncio.create_task(self._util_conn_server.stop()),
         ]
         await asyncio.gather(*tasks)
+
+    def get_host_port(self):
+        return self._host_conn_server.get_port()
+
+    def get_util_port(self):
+        return self._util_conn_server.get_port()

--- a/opencis/cxl/component/mctp/mctp_connection_manager.py
+++ b/opencis/cxl/component/mctp/mctp_connection_manager.py
@@ -41,15 +41,14 @@ class MctpConnectionManager(RunnableComponent):
         self._connection_timeout_ms = connection_timeout_ms
         # TODO: Support receiving connections from CXL Devices
         self._switch_port = MctpPort()
-        self._server_component = None
-
-    async def _run(self):
         self._server_component = ServerComponent(
             handle_client=self._handle_client,
             host=self._host,
             port=self._port,
             stop_callback=self._stop_callback,
         )
+
+    async def _run(self):
         server_task = asyncio.create_task(self._server_component.run())
         await self._server_component.wait_for_ready()
         self._port = self._server_component.get_port()

--- a/opencis/cxl/component/mctp/mctp_connection_manager.py
+++ b/opencis/cxl/component/mctp/mctp_connection_manager.py
@@ -16,6 +16,7 @@ from opencis.cxl.component.mctp.mctp_packet_processor import (
     MCTP_PACKET_PROCESSOR_TYPE,
 )
 from opencis.util.component import RunnableComponent
+from opencis.util.server import ServerComponent
 
 # pylint: disable=duplicate-code
 
@@ -40,57 +41,44 @@ class MctpConnectionManager(RunnableComponent):
         self._connection_timeout_ms = connection_timeout_ms
         # TODO: Support receiving connections from CXL Devices
         self._switch_port = MctpPort()
-        self._server_task = None
+        self._server_component = None
 
     async def _run(self):
-        # pylint: disable=bare-except
-        try:
-            logger.info(self._create_message(f"Creating TCP server at port {self._port}"))
-            server = await self._create_server()
-            self._server_task = asyncio.create_task(server.serve_forever())
-            logger.info(self._create_message("Starting TCP server task"))
-            while not server.is_serving():
-                await asyncio.sleep(0.1)
-            await self._change_status_to_running()
-            await self._server_task
-        except Exception as e:
-            logger.debug(self._create_message(f"Exception: {str(e)}"))
-        except:
-            logger.info(self._create_message("Stopped TCP server"))
-            if self._switch_port.packet_processor is not None:
-                logger.info(self._create_message("Stopping PacketProcessor for Switch Port"))
-                await self._switch_port.packet_processor.stop()
-                logger.info(self._create_message("Stopped PacketProcessor for Switch Port"))
+        self._server_component = ServerComponent(
+            handle_client=self._handle_client,
+            host=self._host,
+            port=self._port,
+            stop_callback=self._stop_callback,
+        )
+        server_task = asyncio.create_task(self._server_component.run())
+        await self._server_component.wait_for_ready()
+        self._port = self._server_component.get_port()
+        await self._change_status_to_running()
+        await server_task
+
+    async def _stop_callback(self):
+        if self._switch_port.packet_processor is not None:
+            logger.info(self._create_message("Stopping PacketProcessor for Switch Port"))
+            await self._switch_port.packet_processor.stop()
+            logger.info(self._create_message("Stopped PacketProcessor for Switch Port"))
 
     async def _stop(self):
         logger.info(self._create_message("Canceling TCP server task"))
-        self._server_task.cancel()
+        await self._server_component.stop()
 
-    async def _create_server(self):
-        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
-            try:
-                logger.info(self._create_message("Found a new socket connection"))
-                if self._switch_port.connected:
-                    logger.warning(
-                        self._create_message("Connection already exists for Switch Port")
-                    )
-                else:
-                    logger.info(self._create_message("Binding incoming connection to Switch Port"))
-                    self._switch_port.connected = True
-                    await self._start_packet_processor(reader, writer)
-            except Exception as e:
-                logger.warning(self._create_message(str(e)))
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            logger.info(self._create_message("Found a new socket connection"))
+            if self._switch_port.connected:
+                logger.warning(self._create_message("Connection already exists for Switch Port"))
+            else:
+                logger.info(self._create_message("Binding incoming connection to Switch Port"))
+                self._switch_port.connected = True
+                await self._start_packet_processor(reader, writer)
+        except Exception as e:
+            logger.warning(self._create_message(str(e)))
 
-            self._switch_port.connected = False
-            await self._close_connection(writer)
-
-        server = await asyncio.start_server(handle_client, self._host, self._port)
-        return server
-
-    async def _close_connection(self, writer: asyncio.StreamWriter):
-        writer.close()
-        await writer.wait_closed()
-        logger.info(self._create_message("Closed connnection"))
+        self._switch_port.connected = False
 
     async def _start_packet_processor(
         self,

--- a/opencis/cxl/component/switch_connection_client.py
+++ b/opencis/cxl/component/switch_connection_client.py
@@ -98,6 +98,9 @@ class SwitchConnectionClient(RunnableComponent):
     def get_port_index(self):
         return self._port_index
 
+    def set_port(self, port: int):
+        self._port = port
+
     async def _run(self):
         if self._retry:
             time_out = 120

--- a/opencis/cxl/component/switch_connection_manager.py
+++ b/opencis/cxl/component/switch_connection_manager.py
@@ -6,7 +6,7 @@ See LICENSE for details.
 """
 
 import asyncio
-from asyncio import CancelledError, create_task, gather
+from asyncio import create_task, gather
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import Optional, List, Callable, Coroutine, Any, cast
@@ -29,6 +29,7 @@ from opencis.cxl.component.cxl_component import (
 from opencis.cxl.component.common import CXL_COMPONENT_TYPE
 from opencis.util.component import RunnableComponent
 from opencis.util.logger import logger
+from opencis.util.server import ServerComponent
 
 
 @dataclass
@@ -68,116 +69,52 @@ class SwitchConnectionManager(RunnableComponent):
         self._port = port
         self._connection_timeout_ms = connection_timeout_ms
         self._ports = [SwitchPort(port_config=port_config) for port_config in port_configs]
-        self._server_task = None
+        self._server_component = None
         self._event_handler = None
-        self._clients = set()
 
     async def _run(self):
+        self._server_component = ServerComponent(
+            handle_client=self._handle_client,
+            host=self._host,
+            port=self._port,
+        )
+        server_task = create_task(self._server_component.run())
+        await self._server_component.wait_for_ready()
+        self._port = self._server_component.get_port()
+        await self._change_status_to_running()
+        await server_task
+
+    async def _stop(self):
+        await self._server_component.stop()
+
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        port_index = None
         try:
-            logger.info(self._create_message("Creating TCP server"))
-            server = await self._create_server()
-            self._server_task = asyncio.create_task(server.serve_forever())
-            logger.info(self._create_message("Starting TCP server task"))
-            while not server.is_serving():
-                await asyncio.sleep(0.1)
-            await self._change_status_to_running()
-            await self._server_task
+            logger.info(self._create_message("Found a new socket connection"))
+            port_index = await self._wait_for_connection_request(reader)
+            await self._send_confirmation(writer)
+            logger.info(self._create_message(f"Binding incoming connection to port {port_index}"))
+            await self._update_connection_status(port_index, connected=True)
+            await self._start_packet_processor(reader, writer, port_index)
         except Exception as e:
             logger.error(
                 self._create_message(
                     f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
                 )
             )
-        except CancelledError:
-            logger.info(self._create_message("Stopped TCP server"))
 
-    async def _stop(self):
-        logger.info(self._create_message("Cancelling TCP server task"))
-        self._server_task.cancel()
-        for client in self._clients.copy():
-            logger.info(
-                self._create_message(
-                    f'Closing client connection: {client.get_extra_info("peername")}'
-                )
-            )
-            client.close()
-        for client in self._clients.copy():
-            await client.wait_closed()
-            logger.info(
-                self._create_message(
-                    f'Closed client connection: {client.get_extra_info("peername")}'
-                )
-            )
-        self._clients.clear()
-        try:
-            await self._server_task
-        except CancelledError:
-            logger.info(self._create_message("Cancelled TCP server"))
-
-    async def _create_server(self):
-        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
-            self._clients.add(writer)
-            port_index = None
-            try:
-                logger.info(
-                    self._create_message(
-                        f"Found a new socket connection: {writer.get_extra_info('peername')}"
-                    )
-                )
-                port_index = await self._wait_for_connection_request(reader)
-                await self._send_confirmation(writer)
-                logger.info(
-                    self._create_message(f"Binding incoming connection to port {port_index}")
-                )
-                await self._update_connection_status(port_index, connected=True)
-                await self._start_packet_processor(reader, writer, port_index)
-            except Exception as e:
-                logger.error(
-                    self._create_message(
-                        f"{self.__class__.__name__} error: {str(e)}, {traceback.format_exc()}"
-                    )
-                )
-
-            if port_index is None:
-                await self._send_rejection(writer)
-            else:
-                await self._update_connection_status(port_index, connected=False)
-            await self._close_connection(writer, port_index)
-
-        logger.info(self._create_message(f"Listening to port {self._port}"))
-        server = await asyncio.start_server(handle_client, self._host, self._port)
-        return server
+        if port_index is None:
+            await self._send_rejection(writer)
+            # Connection closed log printed from ServerComponent
+        else:
+            await self._update_connection_status(port_index, connected=False)
+            logger.info(self._create_message(f"Closed client connection for port {port_index}"))
 
     async def _update_connection_status(self, port_id: int, connected: bool):
         self._ports[port_id].connected = connected
         if not self._event_handler:
             return
         await self._event_handler(PortUpdateEvent(port_id=port_id, connected=connected))
-
-    async def _close_connection(
-        self, writer: asyncio.StreamWriter, port_index: Optional[int] = None
-    ):
-        description = writer.get_extra_info("peername")
-        self._clients.discard(writer)
-        writer.close()
-        try:
-            await writer.wait_closed()
-        except Exception as e:
-            logger.error(
-                self._create_message(
-                    f"{self.__class__.__name__} error while closing {description}: "
-                    f"{str(e)}, {traceback.format_exc()}"
-                )
-            )
-
-        if port_index is None:
-            logger.info(self._create_message(f"Closed client connection: {description}"))
-        else:
-            logger.info(
-                self._create_message(
-                    f"Closed client connection {description} for port {port_index}"
-                )
-            )
 
     async def _send_confirmation(self, writer: asyncio.StreamWriter):
         sideband_response = BaseSidebandPacket.create(SIDEBAND_TYPES.CONNECTION_ACCEPT)
@@ -261,3 +198,6 @@ class SwitchConnectionManager(RunnableComponent):
 
     def register_event_handler(self, event_handler: AsyncEventHandlerType):
         self._event_handler = event_handler
+
+    def get_port(self):
+        return self._port

--- a/opencis/cxl/component/virtual_switch/virtual_switch.py
+++ b/opencis/cxl/component/virtual_switch/virtual_switch.py
@@ -298,3 +298,6 @@ class CxlVirtualSwitch(RunnableComponent):
 
     def register_event_handler(self, event_handler: AsyncEventHandlerType):
         self._event_handler = event_handler
+
+    def get_irq_port(self):
+        return self._irq_manager.get_port()

--- a/opencis/cxl/component/virtual_switch/virtual_switch.py
+++ b/opencis/cxl/component/virtual_switch/virtual_switch.py
@@ -296,8 +296,8 @@ class CxlVirtualSwitch(RunnableComponent):
     def get_ld_id(self, vppb_id: int) -> int:
         return self._vppb_ld_id_map[vppb_id]
 
-    def register_event_handler(self, event_handler: AsyncEventHandlerType):
-        self._event_handler = event_handler
-
     def get_irq_port(self):
         return self._irq_manager.get_port()
+
+    def register_event_handler(self, event_handler: AsyncEventHandlerType):
+        self._event_handler = event_handler

--- a/opencis/cxl/component/virtual_switch_manager.py
+++ b/opencis/cxl/component/virtual_switch_manager.py
@@ -93,3 +93,6 @@ class VirtualSwitchManager(RunnableComponent):
     def register_event_handler(self, event_handler: AsyncEventHandlerType):
         for vcs in self._virtual_switches:
             vcs.register_event_handler(event_handler)
+
+    def get_port(self, switch_index):
+        return self._virtual_switches[switch_index].get_irq_port()

--- a/opencis/cxl/component/virtual_switch_manager.py
+++ b/opencis/cxl/component/virtual_switch_manager.py
@@ -73,6 +73,13 @@ class VirtualSwitchManager(RunnableComponent):
             total_bound_vppbs += virtual_switch.get_bound_vppb_counts()
         return total_bound_vppbs
 
+    def get_port(self, switch_index):
+        return self._virtual_switches[switch_index].get_irq_port()
+
+    def register_event_handler(self, event_handler: AsyncEventHandlerType):
+        for vcs in self._virtual_switches:
+            vcs.register_event_handler(event_handler)
+
     async def _run(self):
         run_tasks = []
         for virtual_switch in self._virtual_switches:
@@ -89,10 +96,3 @@ class VirtualSwitchManager(RunnableComponent):
         for virtual_switch in self._virtual_switches:
             tasks.append(create_task(virtual_switch.stop()))
         await gather(*tasks)
-
-    def register_event_handler(self, event_handler: AsyncEventHandlerType):
-        for vcs in self._virtual_switches:
-            vcs.register_event_handler(event_handler)
-
-    def get_port(self, switch_index):
-        return self._virtual_switches[switch_index].get_irq_port()

--- a/opencis/util/server.py
+++ b/opencis/util/server.py
@@ -1,0 +1,128 @@
+"""
+Copyright (c) 2025, Eeum, Inc.
+
+This software is licensed under the terms of the Revised BSD License.
+See LICENSE for details.
+"""
+
+import asyncio
+from asyncio import CancelledError
+import sys
+from typing import Callable
+import traceback
+
+from opencis.util.component import RunnableComponent
+from opencis.util.logger import logger
+
+
+class ServerComponent(RunnableComponent):
+    def __init__(
+        self,
+        handle_client: Callable,
+        host: str = "0.0.0.0",
+        port: int = 0,
+        limit: int = 0,
+        stop_callback: Callable = None,
+        label=None,
+    ):
+        if label is None:
+            # Get caller function name
+            # pylint: disable=protected-access
+            label = sys._getframe(1).f_locals["self"].__class__.__name__
+        super().__init__(label)
+
+        if handle_client is None:
+            raise ValueError("handle_client must be provided")
+
+        self._host = host
+        self._port = port
+        self._limit = limit
+        self._handle_client = handle_client
+        self._stop_callback = stop_callback
+        self._descriptor = f"TCP server ({label})"
+        self._server_task = None
+        self._clients = set()
+
+    async def _run(self):
+        try:
+            logger.info(self._create_message(f"Creating {self._descriptor}"))
+            server = await self._create_server()
+            self._server_task = asyncio.create_task(server.serve_forever())
+            while not server.is_serving():
+                await asyncio.sleep(0.1)
+            await self._change_status_to_running()
+            await self._server_task
+        except Exception as e:
+            logger.error(
+                self._create_message(
+                    f"{self._descriptor} error: {str(e)}, {traceback.format_exc()}"
+                )
+            )
+        except CancelledError:
+            logger.info(self._create_message(f"Stopped {self._descriptor}"))
+            if self._stop_callback is not None:
+                await self._stop_callback()
+
+    async def _stop(self):
+        logger.info(self._create_message(f"Cancelling {self._descriptor} task"))
+        self._server_task.cancel()
+        for client in self._clients.copy():
+            logger.info(
+                self._create_message(
+                    f'Closing client connection: {client.get_extra_info("peername")}'
+                )
+            )
+            client.close()
+        for client in self._clients.copy():
+            await client.wait_closed()
+            logger.info(
+                self._create_message(
+                    f'Closed client connection: {client.get_extra_info("peername")}'
+                )
+            )
+        self._clients.clear()
+        try:
+            await self._server_task
+        except CancelledError:
+            logger.info(self._create_message(f"Cancelled {self._descriptor}"))
+
+    async def _create_server(self):
+        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+            self._clients.add(writer)
+            logger.info(
+                self._create_message(
+                    f"Found a new socket connection: {writer.get_extra_info('peername')}"
+                )
+            )
+            await self._handle_client(reader, writer)
+            # Handled, now close the connection
+            self._clients.discard(writer)
+            description = writer.get_extra_info("peername")
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception as e:
+                logger.error(
+                    self._create_message(
+                        f"Error while closing {description}: {str(e)}, {traceback.format_exc()}"
+                    )
+                )
+            logger.info(self._create_message(f"Closed client connection: {description}"))
+
+        logger.info(self._create_message(f"Starting {self._descriptor} server"))
+        if self._limit == 0:
+            server = await asyncio.start_server(handle_client, self._host, self._port)
+        else:
+            server = await asyncio.start_server(
+                handle_client, self._host, self._port, limit=self._limit
+            )
+        if self._port == 0:
+            # Ephemeral port is chosen by the OS
+            self._port = server.sockets[0].getsockname()[1]
+        logger.info(
+            self._create_message(f"{self._descriptor} listening on {self._host}:{self._port}")
+        )
+        return server
+
+    def get_port(self):
+        return self._port

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ This software is licensed under the terms of the Revised BSD License.
 See LICENSE for details.
 """
 
-from enum import IntEnum, auto
 import pytest
 
 
@@ -20,24 +19,3 @@ def get_gold_std_reg_vals():
         return None
 
     return _get_gold_std_reg_vals
-
-
-class TEST_PORT(IntEnum):
-    TEST_1 = auto()
-    TEST_2 = auto()
-    TEST_3 = auto()
-    TEST_4 = auto()
-    TEST_5 = auto()
-    TEST_6 = auto()
-    TEST_7 = auto()
-    TEST_8 = auto()
-    TEST_9 = auto()
-    TEST_10 = auto()
-    TEST_11 = auto()
-    TEST_12 = auto()
-    TEST_13 = auto()
-    TEST_14 = auto()
-
-
-def pytest_configure():
-    pytest.PORT = TEST_PORT

--- a/tests/test_cxl_component_physical_port_manager.py
+++ b/tests/test_cxl_component_physical_port_manager.py
@@ -16,11 +16,6 @@ from opencis.cxl.component.physical_port_manager import (
     DownstreamPortDevice,
 )
 from opencis.cxl.component.switch_connection_manager import SwitchConnectionManager
-from opencis.util.number import get_rand_range_generator
-
-
-BASE_TEST_PORT = 9000
-generator = get_rand_range_generator(BASE_TEST_PORT, 100)
 
 
 @pytest.mark.asyncio
@@ -33,8 +28,7 @@ async def test_physical_port_manager_init(get_gold_std_reg_vals):
         PortConfig(PORT_TYPE.DSP),
         PortConfig(PORT_TYPE.DSP),
     ]
-    port = next(generator)
-    switch_connection_manager = SwitchConnectionManager(port_configs, port=port)
+    switch_connection_manager = SwitchConnectionManager(port_configs, port=0)
     physical_port_manager = PhysicalPortManager(
         switch_connection_manager=switch_connection_manager, port_configs=port_configs
     )
@@ -67,8 +61,7 @@ async def test_physical_port_manager_run_and_stop():
         PortConfig(PORT_TYPE.DSP),
         PortConfig(PORT_TYPE.DSP),
     ]
-    port = next(generator)
-    switch_connection_manager = SwitchConnectionManager(port_configs, port=port)
+    switch_connection_manager = SwitchConnectionManager(port_configs, port=0)
     physical_port_manager = PhysicalPortManager(
         switch_connection_manager=switch_connection_manager, port_configs=port_configs
     )
@@ -90,8 +83,7 @@ async def test_physical_port_manager_stop_before_run():
         PortConfig(PORT_TYPE.DSP),
         PortConfig(PORT_TYPE.DSP),
     ]
-    port = next(generator)
-    switch_connection_manager = SwitchConnectionManager(port_configs, port=port)
+    switch_connection_manager = SwitchConnectionManager(port_configs, port=0)
     physical_port_manager = PhysicalPortManager(
         switch_connection_manager=switch_connection_manager, port_configs=port_configs
     )
@@ -109,8 +101,7 @@ async def test_physical_port_manager_run_after_run():
         PortConfig(PORT_TYPE.DSP),
         PortConfig(PORT_TYPE.DSP),
     ]
-    port = next(generator)
-    switch_connection_manager = SwitchConnectionManager(port_configs, port=port)
+    switch_connection_manager = SwitchConnectionManager(port_configs, port=0)
     physical_port_manager = PhysicalPortManager(
         switch_connection_manager=switch_connection_manager, port_configs=port_configs
     )

--- a/tests/test_cxl_component_switch_bind.py
+++ b/tests/test_cxl_component_switch_bind.py
@@ -74,7 +74,7 @@ async def test_single_logical_device_bind_unbind():
         vppb_counts=vppb_counts,
         initial_bounds=initial_bounds,
         physical_ports=physical_ports,
-        irq_port=8500 + pytest.PORT.TEST_1,
+        irq_port=0,
         allocated_ld=allocated_ld,
     )
 
@@ -185,7 +185,7 @@ async def test_multi_logical_device_bind_unbind():
         vppb_counts=vppb_counts,
         initial_bounds=initial_bounds,
         physical_ports=physical_ports,
-        irq_port=8500 + pytest.PORT.TEST_1,
+        irq_port=0,
         allocated_ld=allocated_ld,
     )
 

--- a/tests/test_cxl_component_virtual_switch.py
+++ b/tests/test_cxl_component_virtual_switch.py
@@ -229,7 +229,7 @@ async def test_virtual_switch_manager_run_and_stop():
         vppb_counts=vppb_counts,
         initial_bounds=initial_bounds,
         physical_ports=physical_ports,
-        irq_port=8500 + pytest.PORT.TEST_1,
+        irq_port=0,
         allocated_ld=allocated_ld,
     )
 

--- a/tests/test_cxl_component_virtual_switch_manager.py
+++ b/tests/test_cxl_component_virtual_switch_manager.py
@@ -22,11 +22,6 @@ from opencis.cxl.component.virtual_switch_manager import (
     CxlVirtualSwitch,
 )
 from opencis.util.unaligned_bit_structure import UnalignedBitStructure
-from opencis.util.number import get_rand_range_generator
-
-
-BASE_TEST_PORT = 9200
-generator = get_rand_range_generator(BASE_TEST_PORT, 100)
 
 
 def test_virtual_switch_manager_init():
@@ -37,8 +32,7 @@ def test_virtual_switch_manager_init():
         PortConfig(PORT_TYPE.DSP),
         PortConfig(PORT_TYPE.DSP),
     ]
-    port = next(generator)
-    switch_connection_manager = SwitchConnectionManager(port_configs, port=port)
+    switch_connection_manager = SwitchConnectionManager(port_configs, port=0)
     physical_port_manager = PhysicalPortManager(
         switch_connection_manager=switch_connection_manager, port_configs=port_configs
     )
@@ -50,7 +44,7 @@ def test_virtual_switch_manager_init():
             vppb_counts=vppb_counts,
             initial_bounds=initial_bounds,
             irq_host="127.0.0.1",
-            irq_port=next(generator),
+            irq_port=0,
         )
     ]
     allocated_ld = {}
@@ -78,8 +72,7 @@ async def test_virtual_switch_manager_run_and_stop():
         PortConfig(PORT_TYPE.DSP),
         PortConfig(PORT_TYPE.DSP),
     ]
-    port = next(generator)
-    switch_connection_manager = SwitchConnectionManager(port_configs, port=port)
+    switch_connection_manager = SwitchConnectionManager(port_configs, port=0)
     physical_port_manager = PhysicalPortManager(
         switch_connection_manager=switch_connection_manager, port_configs=port_configs
     )
@@ -91,7 +84,7 @@ async def test_virtual_switch_manager_run_and_stop():
             vppb_counts=vppb_counts,
             initial_bounds=initial_bounds,
             irq_host="127.0.0.1",
-            irq_port=next(generator),
+            irq_port=0,
         )
     ]
     allocated_ld = {}

--- a/tests/test_cxl_host.py
+++ b/tests/test_cxl_host.py
@@ -315,7 +315,7 @@ async def test_cxl_host_type3_ete():
         serial_number="DDDDDDDDDDDDDDDD",
         port=sw_conn_manager.get_port(),
     )
-    await sld.run_wait_ready()
+    start_tasks += [await sld.run_wait_ready()]
 
     print(f"irq_port: {virtual_switch_manager.get_port(0)}")
     cxl_host_config = CxlHostConfig(
@@ -331,7 +331,7 @@ async def test_cxl_host_type3_ete():
         enable_hm=False,
     )
     host = CxlHost(cxl_host_config)
-    await host.run_wait_ready()
+    start_tasks += [await host.run_wait_ready()]
 
     data = 0xA5A5
     valid_addr = 0x40


### PR DESCRIPTION
…ning tests

Helper component, ServerComponent, was added to opencis/util/server.py that wraps asyncio server for ease of use.

All asyncio.create_task(server.serve_forever()) from opencis/ (ShortMsgConn, SwitchConnectionManager, MctpConnectionManager) now uses it.

Additionally, all server code now supports taking 0 as the port number to allow the kernel to assign an unused ephemeral port.

Dependent client classes now have set_port(int) for assigning said port number from the server class, which also now have get_port() helper function.

This fixes tests failure due to duplicate port numbers once and for all and even allows concurrent pytests.