### PR TITLE
Fix premature connection closes in ShortMsgConn

### DIFF
--- a/opencis/cxl/component/short_msg_conn.py
+++ b/opencis/cxl/component/short_msg_conn.py
@@ -58,6 +58,7 @@ class ShortMsgConn(RunnableComponent):
                 handle_client=self._new_conn,
                 host=self._addr,
                 port=self._port,
+                leave_opened=True,
             )
         else:
             self._server_component = None


### PR DESCRIPTION
ShortMsgConn wants to keep using the connections made from handle_client().

Add an optional boolean argument leave_opened to ServerComponent and use it from ShortMsgConn.