### PR TITLE
Fix SocketIO client key values

### DIFF
--- a/opencis/bin/socketio_client.py
+++ b/opencis/bin/socketio_client.py
@@ -122,7 +122,7 @@ async def get_ld_info(port_index: int):
     await sio.connect("http://0.0.0.0:8200")
     await send(
         "mld:get",
-        {"port_index": port_index},
+        {"portIndex": port_index},
     )
     await sio.disconnect()
 
@@ -132,9 +132,9 @@ async def get_ld_allocation(port_index: int, start_ld_id: int, ld_allocation_lis
     await send(
         "mld:getAllocation",
         {
-            "port_index": port_index,
-            "start_ld_id": start_ld_id,
-            "ld_allocation_list_limit": ld_allocation_list_limit,
+            "portIndex": port_index,
+            "startLdId": start_ld_id,
+            "ldAllocationListLimit": ld_allocation_list_limit,
         },
     )
     await sio.disconnect()
@@ -147,10 +147,10 @@ async def set_ld_allocation(
     await send(
         "mld:setAllocation",
         {
-            "port_index": port_index,
-            "number_of_lds": number_of_lds,
-            "start_ld_id": start_ld_id,
-            "ld_allocation_list": ld_allocation_list,
+            "portIndex": port_index,
+            "numberOfLds": number_of_lds,
+            "startLdId": start_ld_id,
+            "ldAllocationList": ld_allocation_list,
         },
     )
     await sio.disconnect()


### PR DESCRIPTION
Commit e0c70114eb38 ("Fix JSON format for mld:getAllocation (#179)") changed the key formats and opencis/bin/socketio_client.py should've also changed.

Fixes: e0c70114eb38 ("Fix JSON format for mld:getAllocation (#179)")